### PR TITLE
Added support for Unity 2019.4 - 2021.2

### DIFF
--- a/Nodes/Complex/ComplexNodes.cs
+++ b/Nodes/Complex/ComplexNodes.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 
 [Title("Math", "Complex", "Complex Conjugate")]
-public class ComplexConjugateNode : CodeFunctionNode {
+internal class ComplexConjugateNode : CodeFunctionNode {
 	public ComplexConjugateNode() {
 		name = "Complex Conjugate";
 	}
@@ -26,7 +26,7 @@ public class ComplexConjugateNode : CodeFunctionNode {
 }
 
 [Title("Math", "Complex", "Complex Reciprocal")]
-public class ComplexReciprocalNode : CodeFunctionNode {
+internal class ComplexReciprocalNode : CodeFunctionNode {
 	public ComplexReciprocalNode() {
 		name = "Complex Reciprocal";
 	}
@@ -46,7 +46,7 @@ public class ComplexReciprocalNode : CodeFunctionNode {
 }
 
 [Title("Math", "Complex", "Complex Multiply")]
-public class ComplexMultiplyNode : CodeFunctionNode {
+internal class ComplexMultiplyNode : CodeFunctionNode {
 	public ComplexMultiplyNode() {
 		name = "Complex Multiply";
 	}
@@ -66,7 +66,7 @@ public class ComplexMultiplyNode : CodeFunctionNode {
 }
 
 [Title("Math", "Complex", "Complex Divide")]
-public class ComplexDivideNode : CodeFunctionNode {
+internal class ComplexDivideNode : CodeFunctionNode {
 	public ComplexDivideNode() {
 		name = "Complex Divide";
 	}
@@ -86,7 +86,7 @@ public class ComplexDivideNode : CodeFunctionNode {
 }
 
 [Title("Math", "Complex", "Complex Exponential")]
-public class ComplexExponentialNode : CodeFunctionNode {
+internal class ComplexExponentialNode : CodeFunctionNode {
 	public ComplexExponentialNode() {
 		name = "Complex Exponential";
 	}
@@ -108,7 +108,7 @@ public class ComplexExponentialNode : CodeFunctionNode {
 }
 
 [Title("Math", "Complex", "Complex Logarithm")]
-public class ComplexLogarithmNode : CodeFunctionNode {
+internal class ComplexLogarithmNode : CodeFunctionNode {
 	public ComplexLogarithmNode() {
 		name = "Complex Logarithm";
 	}
@@ -128,7 +128,7 @@ public class ComplexLogarithmNode : CodeFunctionNode {
 }
 
 [Title("Math", "Complex", "Complex Power")]
-public class ComplexPowerNode : CodeFunctionNode {
+internal class ComplexPowerNode : CodeFunctionNode {
 	public ComplexPowerNode() {
 		name = "Complex Power";
 	}

--- a/Nodes/Composite/CompositeNodes.cs
+++ b/Nodes/Composite/CompositeNodes.cs
@@ -17,7 +17,7 @@ public enum CompositeMode
 }
 
 [Title("Compositing", "Composite")]
-public class CompositeNode : CodeFunctionNode {
+internal class CompositeNode : CodeFunctionNode {
     [SerializeField]
     private CompositeMode m_CompositeMode = CompositeMode.Over;
     

--- a/Nodes/Gilescoope.ShaderGraphNodes.Internal.asmref
+++ b/Nodes/Gilescoope.ShaderGraphNodes.Internal.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:be0903cd8e1546f498710afdc59db5eb"
+}

--- a/Nodes/Gilescoope.ShaderGraphNodes.Internal.asmref.meta
+++ b/Nodes/Gilescoope.ShaderGraphNodes.Internal.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9ec9568158df4a24a9c70fd5f68c34b5
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Nodes/Halftone/HalftoneNodes.cs
+++ b/Nodes/Halftone/HalftoneNodes.cs
@@ -14,7 +14,7 @@ public enum HalftoneMode {
 }
 
 [Title("Halftone", "Halftone Monochrome")]
-public class HalftoneMonochromeNode : CodeFunctionNode {
+internal class HalftoneMonochromeNode : CodeFunctionNode {
     [SerializeField] private HalftoneMode m_HalftoneMode = HalftoneMode.Circle;
 
     public HalftoneMonochromeNode() {
@@ -85,7 +85,7 @@ public class HalftoneMonochromeNode : CodeFunctionNode {
 }
 
 [Title("Halftone", "Halftone Color")]
-public class HalftoneColorNode : CodeFunctionNode {
+internal class HalftoneColorNode : CodeFunctionNode {
     [SerializeField] private HalftoneMode m_HalftoneMode = HalftoneMode.Circle;
 
     public HalftoneColorNode() {

--- a/Nodes/Lab Color/LabColorNodes.cs
+++ b/Nodes/Lab Color/LabColorNodes.cs
@@ -7,7 +7,7 @@ using UnityEditor.ShaderGraph.Drawing.Controls;
 using UnityEngine;
 
 [Title("Artistic", "Utility", "Color Scheme Complimentary")]
-public class ComplimentaryNode : CodeFunctionNode {
+internal class ComplimentaryNode : CodeFunctionNode {
     public ComplimentaryNode() {
         name = "Color Scheme Complimentary";
     }
@@ -45,7 +45,7 @@ public class ComplimentaryNode : CodeFunctionNode {
 }
 
 [Title("Artistic", "Utility", "Color Scheme Split")]
-public class SplitNode : CodeFunctionNode {
+internal class SplitNode : CodeFunctionNode {
     public SplitNode() {
         name = "Color Scheme Split";
     }
@@ -93,7 +93,7 @@ public class SplitNode : CodeFunctionNode {
 }
 
 [Title("Artistic", "Utility", "Color Scheme Dual")]
-public class DualNode : CodeFunctionNode {
+internal class DualNode : CodeFunctionNode {
     public DualNode() {
         name = "Color Scheme Dual";
     }
@@ -177,7 +177,7 @@ public struct LabColorspaceConversion : IEnumConversion {
 }
 
 [Title("Artistic", "Utility", "Lab Colorspace Conversion")]
-public class LabColorspaceConversionNode : CodeFunctionNode {
+internal class LabColorspaceConversionNode : CodeFunctionNode {
     [SerializeField] private LabColorspaceConversion m_Conversion = new LabColorspaceConversion(LabColorspace.RGB, LabColorspace.RGB);
 
     public LabColorspaceConversionNode() {

--- a/Nodes/Pattern/PatternNodes.cs
+++ b/Nodes/Pattern/PatternNodes.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 using UnityEngine;
 
 [Title("Pattern", "Zig Zag")]
-public class ZigZagNode : CodeFunctionNode {
+internal class ZigZagNode : CodeFunctionNode {
     public ZigZagNode() {
         name = "Zig Zag";
     }
@@ -27,7 +27,7 @@ public class ZigZagNode : CodeFunctionNode {
 }
 
 [Title("Pattern", "Sine Waves")]
-public class SineWavesNode : CodeFunctionNode {
+internal class SineWavesNode : CodeFunctionNode {
     public SineWavesNode() {
         name = "Sine Waves";
     }
@@ -51,7 +51,7 @@ public class SineWavesNode : CodeFunctionNode {
 }
 
 [Title("Pattern", "Round Waves")]
-public class RoundWavesNode : CodeFunctionNode {
+internal class RoundWavesNode : CodeFunctionNode {
     public RoundWavesNode() {
         name = "Round Waves";
     }
@@ -81,7 +81,7 @@ public class RoundWavesNode : CodeFunctionNode {
 }
 
 [Title("Pattern", "Dots")]
-public class DotsNode : CodeFunctionNode {
+internal class DotsNode : CodeFunctionNode {
     public DotsNode() {
         name = "Dots";
     }
@@ -110,7 +110,7 @@ public class DotsNode : CodeFunctionNode {
 }
 
 [Title("Pattern", "Spiral")]
-public class SpiralNode : CodeFunctionNode {
+internal class SpiralNode : CodeFunctionNode {
     public SpiralNode() {
         name = "Spiral";
     }
@@ -135,7 +135,7 @@ public class SpiralNode : CodeFunctionNode {
 
 
 [Title("Pattern", "Whirl")]
-public class WhirlNode : CodeFunctionNode {
+internal class WhirlNode : CodeFunctionNode {
     public WhirlNode() {
         name = "Whirl";
     }

--- a/Nodes/Pixel Perfect/PixelPerfectNodes.cs
+++ b/Nodes/Pixel Perfect/PixelPerfectNodes.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 using UnityEngine;
 
 [Title("Pixel Perfect", "Pixel Point")]
-public class PixelPointNode : CodeFunctionNode {
+internal class PixelPointNode : CodeFunctionNode {
 	public PixelPointNode() {
 		name = "Pixel Point";
 	}
@@ -32,7 +32,7 @@ public class PixelPointNode : CodeFunctionNode {
 }
 
 [Title("Pixel Perfect", "Pixel Point Grid")]
-public class PixelPointGridNode : CodeFunctionNode {
+internal class PixelPointGridNode : CodeFunctionNode {
 	public PixelPointGridNode() {
 		name = "Pixel Point Grid";
 	}
@@ -62,7 +62,7 @@ public class PixelPointGridNode : CodeFunctionNode {
 }
 
 [Title("Pixel Perfect", "Pixel Ray")]
-public class PixelRayNode : CodeFunctionNode {
+internal class PixelRayNode : CodeFunctionNode {
 	public PixelRayNode() {
 		name = "Pixel Ray";
 	}
@@ -89,7 +89,7 @@ public class PixelRayNode : CodeFunctionNode {
 }
 
 [Title("Pixel Perfect", "Pixel Rays")]
-public class PixelRaysNode : CodeFunctionNode {
+internal class PixelRaysNode : CodeFunctionNode {
 	public PixelRaysNode() {
 		name = "Pixel Rays";
 	}
@@ -119,7 +119,7 @@ public class PixelRaysNode : CodeFunctionNode {
 }
 
 [Title("Pixel Perfect", "Pixel Line")]
-public class PixelLineNode : CodeFunctionNode {
+internal class PixelLineNode : CodeFunctionNode {
 	public PixelLineNode() {
 		name = "Pixel Line";
 	}
@@ -153,7 +153,7 @@ public class PixelLineNode : CodeFunctionNode {
 }
 
 [Title("Pixel Perfect", "Pixel Lines")]
-public class PixelLinesNode : CodeFunctionNode {
+internal class PixelLinesNode : CodeFunctionNode {
 	public PixelLinesNode() {
 		name = "Pixel Lines";
 	}
@@ -190,7 +190,7 @@ public class PixelLinesNode : CodeFunctionNode {
 }
 
 [Title("Pixel Perfect", "Pixel Circle")]
-public class PixelCircleNode : CodeFunctionNode {
+internal class PixelCircleNode : CodeFunctionNode {
 	public PixelCircleNode() {
 		name = "Pixel Circle";
 	}
@@ -222,7 +222,7 @@ public class PixelCircleNode : CodeFunctionNode {
 }
 
 [Title("Pixel Perfect", "Pixel Polygon")]
-public class PixelPolygonNode : CodeFunctionNode {
+internal class PixelPolygonNode : CodeFunctionNode {
 	public PixelPolygonNode() {
 		name = "Pixel Polygon";
 	}

--- a/Nodes/Quaternion/QuaternionNodes.cs
+++ b/Nodes/Quaternion/QuaternionNodes.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 using UnityEngine;
 
 [Title("Math", "Quaternion", "Quaternion Inverse")]
-public class QuaternionInverseNode : CodeFunctionNode {
+internal class QuaternionInverseNode : CodeFunctionNode {
     public QuaternionInverseNode() {
         name = "Quaternion Inverse";
     }
@@ -25,7 +25,7 @@ public class QuaternionInverseNode : CodeFunctionNode {
 }
 
 [Title("Math", "Quaternion", "Quaternion From Euler")]
-public class QuaternionFromEulerNode : CodeFunctionNode {
+internal class QuaternionFromEulerNode : CodeFunctionNode {
     public QuaternionFromEulerNode() {
         name = "Quaternion From Euler";
     }
@@ -50,7 +50,7 @@ public class QuaternionFromEulerNode : CodeFunctionNode {
 }
 
 [Title("Math", "Quaternion", "Quaternion From Angle Axis")]
-public class QuaternionFromAngleAxisNode : CodeFunctionNode {
+internal class QuaternionFromAngleAxisNode : CodeFunctionNode {
     public QuaternionFromAngleAxisNode() {
         name = "Quaternion From Angle Axis";
     }
@@ -73,7 +73,7 @@ public class QuaternionFromAngleAxisNode : CodeFunctionNode {
 }
 
 [Title("Math", "Quaternion", "Quaternion To Angle Axis")]
-public class QuaternionToAngleAxisNode : CodeFunctionNode {
+internal class QuaternionToAngleAxisNode : CodeFunctionNode {
     public QuaternionToAngleAxisNode() {
         name = "Quaternion To Angle Axis";
     }
@@ -95,7 +95,7 @@ public class QuaternionToAngleAxisNode : CodeFunctionNode {
 }
 
 [Title("Math", "Quaternion", "Quaternion From To Rotation")]
-public class QuaternionFromToRotationNode : CodeFunctionNode {
+internal class QuaternionFromToRotationNode : CodeFunctionNode {
     public QuaternionFromToRotationNode() {
         name = "Quaternion From To Rotation Node";
     }
@@ -116,7 +116,7 @@ public class QuaternionFromToRotationNode : CodeFunctionNode {
 }
 
 [Title("Math", "Quaternion", "Quaternion Multiply")]
-public class QuaternionMultiplyNode : CodeFunctionNode {
+internal class QuaternionMultiplyNode : CodeFunctionNode {
     public QuaternionMultiplyNode() {
         name = "Quaternion Multiply";
     }
@@ -137,7 +137,7 @@ public class QuaternionMultiplyNode : CodeFunctionNode {
 }
 
 [Title("Math", "Quaternion", "Quaternion Rotate Vector")]
-public class QuaternionRotateVectorNode : CodeFunctionNode {
+internal class QuaternionRotateVectorNode : CodeFunctionNode {
     public QuaternionRotateVectorNode() {
         name = "Quaternion Rotate Vector";
     }
@@ -158,7 +158,7 @@ public class QuaternionRotateVectorNode : CodeFunctionNode {
 }
 
 [Title("Math", "Quaternion", "Quaternion Slerp")]
-public class QuaternionSlerpNode : CodeFunctionNode {
+internal class QuaternionSlerpNode : CodeFunctionNode {
     public QuaternionSlerpNode() {
         name = "Quaternion Slerp";
     }

--- a/Nodes/Random/RandomNodes.cs
+++ b/Nodes/Random/RandomNodes.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 
 [Title("Math", "Random", "Random Integer Range")]
-public class RandomIntegerNode : CodeFunctionNode {
+internal class RandomIntegerNode : CodeFunctionNode {
 	public RandomIntegerNode() {
 		name = "Random Integer Range";
 	}
@@ -37,7 +37,7 @@ public enum RandomMode {
 }
 
 [Title("Math", "Random", "Random Circle")]
-public class RandomCircleNode : CodeFunctionNode {
+internal class RandomCircleNode : CodeFunctionNode {
 	[SerializeField] private RandomMode m_RandomMode = RandomMode.In;
 
 	public RandomCircleNode() {
@@ -89,7 +89,7 @@ public class RandomCircleNode : CodeFunctionNode {
 }
 
 [Title("Math", "Random", "Random Sphere")]
-public class RandomSphereNode : CodeFunctionNode {
+internal class RandomSphereNode : CodeFunctionNode {
 	[SerializeField] private RandomMode m_RandomMode = RandomMode.In;
 
 	public RandomSphereNode() {
@@ -145,7 +145,7 @@ public class RandomSphereNode : CodeFunctionNode {
 }
 
 [Title("Math", "Random", "Random Rotation")]
-public class RandomRotationNode : CodeFunctionNode {
+internal class RandomRotationNode : CodeFunctionNode {
 	public RandomRotationNode() {
 		name = "Random Rotation";
 	}
@@ -169,7 +169,7 @@ public class RandomRotationNode : CodeFunctionNode {
 }
 
 [Title("Math", "Random", "Random Color")]
-public class RandomColorNode : CodeFunctionNode {
+internal class RandomColorNode : CodeFunctionNode {
 	public RandomColorNode() {
 		name = "Random Color";
 	}

--- a/Nodes/SDF/SDFNodes.cs
+++ b/Nodes/SDF/SDFNodes.cs
@@ -7,7 +7,7 @@ using UnityEditor.ShaderGraph.Drawing.Controls;
 using UnityEngine;
 
 [Title("SDF", "SDF Line")]
-public class SDFLineNode: CodeFunctionNode {
+internal class SDFLineNode: CodeFunctionNode {
     public SDFLineNode() {
         name = "SDF Line";
     }
@@ -27,7 +27,7 @@ public class SDFLineNode: CodeFunctionNode {
 }
 
 [Title("SDF", "SDF Circle")]
-public class SDFCircleNode: CodeFunctionNode {
+internal class SDFCircleNode: CodeFunctionNode {
     public SDFCircleNode() {
         name = "SDF Circle";
     }
@@ -47,7 +47,7 @@ public class SDFCircleNode: CodeFunctionNode {
 }
 
 [Title("SDF", "SDF Rectangle")]
-public class SDFRectangleNode: CodeFunctionNode {
+internal class SDFRectangleNode: CodeFunctionNode {
     public SDFRectangleNode() {
         name = "SDF Rectangle";
     }
@@ -69,7 +69,7 @@ public class SDFRectangleNode: CodeFunctionNode {
 }
 
 [Title("SDF", "SDF Polygon")]
-public class SDFPolygonNode: CodeFunctionNode {
+internal class SDFPolygonNode: CodeFunctionNode {
     public SDFPolygonNode() {
         name = "SDF Polygon";
     }
@@ -101,7 +101,7 @@ public class SDFPolygonNode: CodeFunctionNode {
 }
 
 [Title("SDF", "SDF Sample")]
-public class SDFSampleNode: CodeFunctionNode {
+internal class SDFSampleNode: CodeFunctionNode {
     public SDFSampleNode() {
         name = "SDF Sample";
     }
@@ -122,7 +122,7 @@ public class SDFSampleNode: CodeFunctionNode {
 }
 
 [Title("SDF", "SDF Sample Strip")]
-public class SDFSampleStripNode: CodeFunctionNode {
+internal class SDFSampleStripNode: CodeFunctionNode {
     public SDFSampleStripNode() {
         name = "SDF Sample Strip";
     }
@@ -150,7 +150,7 @@ public enum BooleanMode
 }
 
 [Title("SDF", "SDF Boolean")]
-public class SDFBooleanNode: CodeFunctionNode {
+internal class SDFBooleanNode: CodeFunctionNode {
     [SerializeField]
     private BooleanMode m_BooleanMode = BooleanMode.Union;
     
@@ -211,7 +211,7 @@ public class SDFBooleanNode: CodeFunctionNode {
 }
 
 [Title("SDF", "SDF Boolean Soft")]
-public class SDFBooleanSoftNode: CodeFunctionNode {
+internal class SDFBooleanSoftNode: CodeFunctionNode {
     [SerializeField]
     private BooleanMode m_BooleanMode = BooleanMode.Union;
     

--- a/Nodes/Symmetry/SymmetryNodes.cs
+++ b/Nodes/Symmetry/SymmetryNodes.cs
@@ -7,7 +7,7 @@ using UnityEditor.ShaderGraph.Drawing.Controls;
 using UnityEngine;
 
 [Title("Symmetry", "Reflection Symmetry")]
-public class ReflectionNode: CodeFunctionNode {
+internal class ReflectionNode: CodeFunctionNode {
     public ReflectionNode() {
         name = "Reflection Symmetry";
     }
@@ -32,7 +32,7 @@ public class ReflectionNode: CodeFunctionNode {
 }
 
 [Title("Symmetry", "Rotation Symmetry")]
-public class RotationNode: CodeFunctionNode {
+internal class RotationNode: CodeFunctionNode {
     public RotationNode() {
         name = "Rotation Symmetry";
     }
@@ -69,7 +69,7 @@ public enum TilingMode {
 
 
 [Title("Symmetry", "Tiling Symmetry")]
-public class TilingNode : CodeFunctionNode {
+internal class TilingNode : CodeFunctionNode {
     [SerializeField] private TilingMode m_TilingMode = TilingMode.Square;
 
     public TilingNode() {

--- a/Nodes/Truchet/TruchetNodes.cs
+++ b/Nodes/Truchet/TruchetNodes.cs
@@ -15,7 +15,7 @@ public enum TruchetMode {
 }
 
 [Title("Truchet", "Truchet")]
-public class TruchetNode : CodeFunctionNode {
+internal class TruchetNode : CodeFunctionNode {
     [SerializeField] private TruchetMode m_TruchetMode = TruchetMode.Square;
 
     public TruchetNode() {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # shader-graph-nodes
+### This fork adds support for Unity 2019.4 and higher!
 
-Custom Nodes for Unity Shader Graph, to be used in Unity 2018.2 with the scriptable render pipeline.
+Custom Nodes for Unity Shader Graph, to be used in new Unity versions with the SRP / URP / HDRP.
 
 [SDF](https://github.com/gilescoope/shader-graph-nodes/tree/master/Nodes/SDF)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # shader-graph-nodes
-### This fork adds support for Unity 2019.4 and higher!
 
-Custom Nodes for Unity Shader Graph, to be used in new Unity versions with the SRP / URP / HDRP.
+Custom Nodes for Unity Shader Graph, to be used in newer Unity versions with the SRP / URP / HDRP.\
+It uses CodeFunctionNode API, which was made internal in 2018.2, but is now accessible using 
+[AsmRef](https://docs.unity.cn/2019.4/Documentation/Manual/class-AssemblyDefinitionReferenceImporter.html).
+
+**Requires Unity 2019.4 or higher.**\
+If you wish to use it in older versions, you'll need to remove .asmref file in Nodes folder.
 
 [SDF](https://github.com/gilescoope/shader-graph-nodes/tree/master/Nodes/SDF)
 


### PR DESCRIPTION
#### **Fork with updated version**: https://github.com/neon-age/shader-graph-nodes

### Issue
This asset still uses CodeFunctionNode API, which was made internal in 2018.2.,
Instead of it, Unity forces us to manually update ALL our nodes to sub-graphs, which is super clumsy and is not as robust. 
We can't do any custom UI or methods selection using it.

### Solution
Instead of rewriting every node to sub-graphs, we'll just **access forbidden API again**, by using AsmRef:
https://docs.unity.cn/2019.4/Documentation/Manual/class-AssemblyDefinitionReferenceImporter.html

Which only required:
- Unity 2019.4 or higher.
- Adding **AsmReference** to main folder with definition to **Unity.ShaderGraph.Editor**. 
This will include and compile all our custom nodes inside ShaderGraph assembly, giving us access to internal API's.
- Changing node classes to be internal to avoid accessibility compile errors.

The CodeFunctionNode API hasn't changed a bit since Unity 2018.2 and works in newer versions up to **2021.2**!
